### PR TITLE
feat: slack notifier added

### DIFF
--- a/.github/workflows/namespace-notifier.yml
+++ b/.github/workflows/namespace-notifier.yml
@@ -2,7 +2,7 @@ name: Buildpack Registry Namespace Notifier
 on: 
   push:
     branches:
-      - slack-test
+      - main
 
 jobs:
   slack-notifier:

--- a/.github/workflows/namespace-notifier.yml
+++ b/.github/workflows/namespace-notifier.yml
@@ -15,3 +15,4 @@ jobs:
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_USERNAME: ${{ github.repository }}
+	SLACK_MESSAGE: A namespace has been updated or created.

--- a/.github/workflows/namespace-notifier.yml
+++ b/.github/workflows/namespace-notifier.yml
@@ -15,4 +15,4 @@ jobs:
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_USERNAME: ${{ github.repository }}
-	SLACK_MESSAGE: A namespace has been updated or created.
+        SLACK_MESSAGE: A namespace has been updated or created.

--- a/.github/workflows/namespace-notifier.yml
+++ b/.github/workflows/namespace-notifier.yml
@@ -1,0 +1,17 @@
+name: Buildpack Registry Namespace Notifier
+on: 
+  push:
+    branches:
+      - slack-test
+
+jobs:
+  slack-notifier:
+    name: Slack Channel Notify
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Channel Notify
+      uses: rtCamp/action-slack-notify@v2.1.2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_USERNAME: ${{ github.repository }}


### PR DESCRIPTION
If merged, please change `push/branches/slack-test` to `push/branches/main`. I have used `slack-test` branch for testing purpose.

For this to work, integration should be added to the channel. `SLACK_WEBHOOK` can be generated from https://slack.com/apps/A0F7XDUAZ-incoming-webhooks 

Please let me know if anything needs to be changed.

Thanks!

Signed-off-by: Aswin Timalsina <aswin.timalsina1@gmail.com>