### PR TITLE
Disable email notifications because they fail

### DIFF
--- a/.github/workflows/namespace-notifier.yml
+++ b/.github/workflows/namespace-notifier.yml
@@ -5,21 +5,21 @@ on:
       - main
 
 jobs:
-  email-maintainers:
-    name: Email Maintainers
-    runs-on: ubuntu-latest
-    steps:
-    - name: Send mail
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: "${{ secrets.MAIL_USERNAME }}"
-        password: "${{ secrets.MAIL_PASSWORD }}"
-        subject: "[${{ github.repository }}] Registry Namespace updated"
-        body: Maintainers, there are some changes in ${{ github.repository }} repository.
-        to: ${{ secrets.CNB_MAINTAINERS_EMAIL }}
-        from: ${{ secrets.MAIL_SENDER }}
+#  email-maintainers:
+#    name: Email Maintainers
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Send mail
+#      uses: dawidd6/action-send-mail@v2
+#      with:
+#        server_address: smtp.gmail.com
+#        server_port: 465
+#        username: "${{ secrets.MAIL_USERNAME }}"
+#        password: "${{ secrets.MAIL_PASSWORD }}"
+#        subject: "[${{ github.repository }}] Registry Namespace updated"
+#        body: Maintainers, there are some changes in ${{ github.repository }} repository.
+#        to: ${{ secrets.CNB_MAINTAINERS_EMAIL }}
+#        from: ${{ secrets.MAIL_SENDER }}
 
 
   slack-notifier:


### PR DESCRIPTION
We've always had trouble configuring the email account. But the Slack notification is sufficient. 