### PR TITLE
Improve Slack notifications

### DIFF
--- a/.github/workflows/namespace-notifier.yml
+++ b/.github/workflows/namespace-notifier.yml
@@ -26,11 +26,12 @@ jobs:
     name: Slack Channel Notify
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Slack Channel Notify
-      uses: rtCamp/action-slack-notify@v2.1.2
+      uses: rtCamp/action-slack-notify@v2.2.1
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_USERNAME: ${{ github.repository }}
-        SLACK_MESSAGE: A namespace has been updated or created.
-
+        # Only include the commit SHA/message in the notification, and not the event type or ref
+        # (which are always 'push' and 'refs/heads/main'), or the GitHub Actions workflow URL.
+        MSG_MINIMAL: "commit"


### PR DESCRIPTION
The Slack notification will now include the commit message of the push to `main` - since when `SLACK_MESSAGE` is omitted, the Slack message defaults to the push's commit message:
https://github.com/rtCamp/action-slack-notify#environment-variables

This makes it possible to see what Registry namespace was added by reading just the Slack message, rather than having to click through to the GitHub repo.

In addition, I have:
- Set `MSG_MINIMAL` to hide the redundant fields previously shown in the Slack message (such as the GitHub Actions workflow URL or the event type/branch)
- Updated the notifier action - changes: https://github.com/rtCamp/action-slack-notify/compare/v2.1.2...v2.2.1
- Updated the checkout action - changes: https://github.com/actions/checkout/compare/v2...v4