### PR TITLE
Remove non-bot users from `heroku` access list

### DIFF
--- a/v1/heroku.json
+++ b/v1/heroku.json
@@ -1,1 +1,1 @@
-{"owners":[{"id":1589,"type":"github_user"},{"id": 177877, "type": "github_user"},{"id": 59744, "type": "github_user"}, {"id": 917672, "type": "github_user"},{"id": 88346006, "type": "github_user"},{"id": 501702, "type": "github_user"}]}
+{"owners":[{"id": 88346006, "type": "github_user"}]}


### PR DESCRIPTION
The Heroku languages team has now fully migrated to automated CNB publishing using a bot service account (a process we'd only just begun at the time of #16), so we no longer need human access to the `heroku` namespace. 

Removing all access apart from the service account improves our security posture and means one less thing that requires a manual step during team on/off-boarding. 

The one remaining user is:
https://api.github.com/user/88346006

Which corresponds to:
https://github.com/heroku-languages-release-bot
